### PR TITLE
feature/continuous zoom

### DIFF
--- a/Metal/Brot.metal
+++ b/Metal/Brot.metal
@@ -26,7 +26,7 @@ typedef enum {
     black, red, orange, yellow, green, blue, indigo, violet
 } LinearColor;
 
-// Color scheme 1: Classic Rainbow
+// Color scheme 0: Classic Rainbow
 float4 colorFromUInt_rainbow(LinearColor color) {
     switch (color) {
         case red: return {1.0, 0.0, 0.0, 1};
@@ -41,7 +41,7 @@ float4 colorFromUInt_rainbow(LinearColor color) {
     return {1, 1, 1, 1};
 }
 
-// Color scheme 2: Warm Sunset
+// Color scheme 1: Warm Sunset
 float4 colorFromUInt_sunset(LinearColor color) {
     switch (color) {
         case red: return {0.8, 0.2, 0.1, 1};
@@ -56,7 +56,7 @@ float4 colorFromUInt_sunset(LinearColor color) {
     return {1, 1, 1, 1};
 }
 
-// Color scheme 3: Cool Ocean
+// Color scheme 2: Cool Ocean
 float4 colorFromUInt_ocean(LinearColor color) {
     switch (color) {
         case red: return {0.1, 0.3, 0.5, 1};
@@ -66,6 +66,111 @@ float4 colorFromUInt_ocean(LinearColor color) {
         case blue: return {0.5, 0.7, 0.9, 1};
         case indigo: return {0.3, 0.5, 0.8, 1};
         case violet: return {0.2, 0.4, 0.7, 1};
+        case black: return {0, 0, 0, 1};
+    }
+    return {1, 1, 1, 1};
+}
+
+// Color scheme 3: Forest Moss
+float4 colorFromUInt_forest(LinearColor color) {
+    switch (color) {
+        case red: return {0.2, 0.3, 0.1, 1};
+        case orange: return {0.3, 0.4, 0.15, 1};
+        case yellow: return {0.4, 0.5, 0.2, 1};
+        case green: return {0.1, 0.6, 0.2, 1};
+        case blue: return {0.1, 0.3, 0.4, 1};
+        case indigo: return {0.15, 0.25, 0.35, 1};
+        case violet: return {0.2, 0.2, 0.3, 1};
+        case black: return {0, 0, 0, 1};
+    }
+    return {1, 1, 1, 1};
+}
+
+// Color scheme 4: Neon Vapor
+float4 colorFromUInt_neon(LinearColor color) {
+    switch (color) {
+        case red: return {1.0, 0.0, 0.6, 1};
+        case orange: return {1.0, 0.2, 0.3, 1};
+        case yellow: return {0.9, 0.8, 0.2, 1};
+        case green: return {0.2, 1.0, 0.6, 1};
+        case blue: return {0.0, 0.6, 1.0, 1};
+        case indigo: return {0.4, 0.2, 1.0, 1};
+        case violet: return {0.8, 0.0, 1.0, 1};
+        case black: return {0, 0, 0, 1};
+    }
+    return {1, 1, 1, 1};
+}
+
+// Color scheme 5: Desert Heat
+float4 colorFromUInt_desert(LinearColor color) {
+    switch (color) {
+        case red: return {0.9, 0.35, 0.1, 1};
+        case orange: return {0.95, 0.5, 0.15, 1};
+        case yellow: return {1.0, 0.7, 0.3, 1};
+        case green: return {0.75, 0.6, 0.25, 1};
+        case blue: return {0.45, 0.35, 0.3, 1};
+        case indigo: return {0.35, 0.25, 0.35, 1};
+        case violet: return {0.5, 0.2, 0.4, 1};
+        case black: return {0, 0, 0, 1};
+    }
+    return {1, 1, 1, 1};
+}
+
+// Color scheme 6: Ice Blue
+float4 colorFromUInt_ice(LinearColor color) {
+    switch (color) {
+        case red: return {0.75, 0.9, 1.0, 1};
+        case orange: return {0.6, 0.85, 1.0, 1};
+        case yellow: return {0.45, 0.8, 1.0, 1};
+        case green: return {0.3, 0.7, 0.95, 1};
+        case blue: return {0.2, 0.6, 0.9, 1};
+        case indigo: return {0.2, 0.5, 0.8, 1};
+        case violet: return {0.2, 0.4, 0.7, 1};
+        case black: return {0, 0, 0, 1};
+    }
+    return {1, 1, 1, 1};
+}
+
+// Color scheme 7: Plasma
+float4 colorFromUInt_plasma(LinearColor color) {
+    switch (color) {
+        case red: return {0.2, 0.0, 0.3, 1};
+        case orange: return {0.35, 0.0, 0.6, 1};
+        case yellow: return {0.6, 0.0, 0.8, 1};
+        case green: return {0.85, 0.2, 0.6, 1};
+        case blue: return {1.0, 0.45, 0.2, 1};
+        case indigo: return {1.0, 0.7, 0.1, 1};
+        case violet: return {0.95, 0.85, 0.2, 1};
+        case black: return {0, 0, 0, 1};
+    }
+    return {1, 1, 1, 1};
+}
+
+// Color scheme 8: Aurora
+float4 colorFromUInt_aurora(LinearColor color) {
+    switch (color) {
+        case red: return {0.05, 0.2, 0.3, 1};
+        case orange: return {0.0, 0.35, 0.45, 1};
+        case yellow: return {0.0, 0.55, 0.6, 1};
+        case green: return {0.0, 0.75, 0.5, 1};
+        case blue: return {0.2, 0.9, 0.4, 1};
+        case indigo: return {0.45, 0.95, 0.6, 1};
+        case violet: return {0.65, 0.9, 0.8, 1};
+        case black: return {0, 0, 0, 1};
+    }
+    return {1, 1, 1, 1};
+}
+
+// Color scheme 9: Monochrome Blue
+float4 colorFromUInt_monochromeBlue(LinearColor color) {
+    switch (color) {
+        case red: return {0.05, 0.1, 0.2, 1};
+        case orange: return {0.1, 0.2, 0.35, 1};
+        case yellow: return {0.15, 0.3, 0.5, 1};
+        case green: return {0.2, 0.4, 0.65, 1};
+        case blue: return {0.25, 0.5, 0.8, 1};
+        case indigo: return {0.35, 0.65, 0.9, 1};
+        case violet: return {0.45, 0.8, 1.0, 1};
         case black: return {0, 0, 0, 1};
     }
     return {1, 1, 1, 1};
@@ -84,6 +189,45 @@ float4 colorFromUInt(LinearColor color) {
         case black: return {0, 0, 0, 1};
     }
     return {1, 1, 1, 1};
+}
+
+float4 paletteColorByScheme(uint scheme, LinearColor color) {
+    switch (scheme) {
+        case 0:
+            return colorFromUInt_rainbow(color);
+        case 1:
+            return colorFromUInt_sunset(color);
+        case 2:
+            return colorFromUInt_ocean(color);
+        case 3:
+            return colorFromUInt_forest(color);
+        case 4:
+            return colorFromUInt_neon(color);
+        case 5:
+            return colorFromUInt_desert(color);
+        case 6:
+            return colorFromUInt_ice(color);
+        case 7:
+            return colorFromUInt_plasma(color);
+        case 8:
+            return colorFromUInt_aurora(color);
+        case 9:
+            return colorFromUInt_monochromeBlue(color);
+        default:
+            return colorFromUInt(color);
+    }
+}
+
+float4 paletteSample(uint scheme, float t) {
+    float clamped = clamp(t, 0.0f, 1.0f);
+    float scaled = clamped * 7.0f;
+    uint idx = (uint)floor(scaled);
+    float frac = scaled - (float)idx;
+    LinearColor c0 = (LinearColor)idx;
+    LinearColor c1 = (LinearColor)min(idx + 1, 7u);
+    float4 col0 = paletteColorByScheme(scheme, c0);
+    float4 col1 = paletteColorByScheme(scheme, c1);
+    return mix(col0, col1, frac);
 }
 
 vertex BrotVertexOut brot_vertex_main(BrotVertexIn vertex_in [[stage_in]],
@@ -130,23 +274,20 @@ fragment FragmentOut brot_fragment_main(BrotVertexOut in [[stage_in]]) {
         iteration++;
     }
     
-    // Use the passed color scheme instead of random selection
-    float4 color;
-    
-    switch (in.colorScheme) {
-        case 0:
-            color = colorFromUInt_rainbow((LinearColor)(uint)iteration);
-            break;
-        case 1:
-            color = colorFromUInt_sunset((LinearColor)(uint)iteration);
-            break;
-        case 2:
-            color = colorFromUInt_ocean((LinearColor)(uint)iteration);
-            break;
-        default:
-            color = colorFromUInt((LinearColor)(uint)iteration);
-            break;
+    float smoothIteration = (float)iteration;
+    if (iteration < ITERATION_MAX) {
+        float modulus = x * x + y * y;
+        float log_zn = log2(modulus) / 2.0;
+        float nu = log2(log_zn);
+        smoothIteration = (float)iteration + 1.0 - nu;
     }
+    
+    float zoomLevel = in.zoom.x / width;
+    float zoomBoost = clamp(log2(zoomLevel + 1.0), 0.0, 6.0);
+    float cycles = 0.08 + (zoomBoost * 0.05);
+    float t = fract(smoothIteration * cycles);
+    
+    float4 color = paletteSample(in.colorScheme, t);
     
     // Blend the calculated color with the passed-in base color
     fragOut.color = (iteration < ITERATION_MAX) ? mix(in.color, color, 0.8) : black;

--- a/Metal/RendererViewModel.swift
+++ b/Metal/RendererViewModel.swift
@@ -183,7 +183,7 @@ final class MetalbrotRendererViewModel: MetalbrotViewModelInterface {
     
     func cycleColorScheme() {
         let currentScheme = selectedColorSchemeConcretePublished
-        let nextScheme = (currentScheme % 3) + 1 // Cycle through schemes 1, 2, 3
+        let nextScheme = (currentScheme + 1) % colorSchemeCount
         print("Cycling color scheme from \(currentScheme) to \(nextScheme)")
         selectedColorSchemeConcretePublished = nextScheme
     }
@@ -197,6 +197,8 @@ final class MetalbrotRendererViewModel: MetalbrotViewModelInterface {
     @Published private var zoomLevelConcretePublished: CGFloat
     @Published private var centerConcretePublished: CGPoint
     @Published private var selectedColorSchemeConcretePublished: UInt32
+    
+    private let colorSchemeCount: UInt32 = 10
     
     private let zoomSpeed: CGFloat
     private let zoomSpeedMinFactor: CGFloat = 0.05
@@ -218,7 +220,7 @@ final class MetalbrotRendererViewModel: MetalbrotViewModelInterface {
         #endif
         zoomLevelConcretePublished = 1
         centerConcretePublished = .zero
-        selectedColorSchemeConcretePublished = 1 // Default to sunset scheme
+        selectedColorSchemeConcretePublished = 0 // Default to rainbow scheme
     }
     
     private func zoomSpeedForLevel(_ level: CGFloat) -> CGFloat {

--- a/Metal/RendererViewModel.swift
+++ b/Metal/RendererViewModel.swift
@@ -24,6 +24,11 @@ protocol MetalbrotViewModelInterface: AnyObject {
     func updateCenter(_ newPoint: CGPoint)
     func updateZoom(_ newZoomLevel: CGFloat)
     func setZoom(_ newZoomLevel: CGFloat)
+    func applyZoom(delta: CGFloat, focus: CGPoint, viewSize: CGSize)
+    func applyZoom(scaleFactor: CGFloat, focus: CGPoint, viewSize: CGSize)
+    func startZoomInertia(deltaVelocity: CGFloat, focus: CGPoint, viewSize: CGSize)
+    func startZoomInertia(scaleVelocity: CGFloat, focus: CGPoint, viewSize: CGSize)
+    func stopZoomInertia()
     
     func requestUpdate()
     
@@ -84,6 +89,93 @@ final class MetalbrotRendererViewModel: MetalbrotViewModelInterface {
         zoomLevelConcretePublished = newZoomLevel
     }
     
+    func applyZoom(scaleFactor: CGFloat, focus: CGPoint, viewSize: CGSize) {
+        let effectiveSpeed = zoomSpeedForLevel(zoomLevelConcretePublished)
+        let safeScale = max(scaleFactor, 0.0001)
+        let delta = log(safeScale) / effectiveSpeed
+        applyZoom(delta: delta, focus: focus, viewSize: viewSize)
+    }
+    
+    func applyZoom(delta: CGFloat, focus: CGPoint, viewSize: CGSize) {
+        guard viewSize.width > 0, viewSize.height > 0 else {
+            return
+        }
+        let effectiveSpeed = zoomSpeedForLevel(zoomLevelConcretePublished)
+        let factor = exp(delta * effectiveSpeed)
+        let oldZoom = max(zoomLevelConcretePublished, 0.0001)
+        let newZoom = min(max(oldZoom * factor, 0.0001), 1000)
+        
+        let oldZoomSize = CGSize(width: viewSize.width * oldZoom, height: viewSize.height * oldZoom)
+        let newZoomSize = CGSize(width: viewSize.width * newZoom, height: viewSize.height * newZoom)
+        
+        let oldOrigin = CGPoint(
+            x: centerConcretePublished.x + (viewSize.width / 2) - (oldZoomSize.width / 2),
+            y: centerConcretePublished.y + (viewSize.height / 2) - (oldZoomSize.height / 2)
+        )
+        
+        let focusNorm = CGPoint(x: focus.x / viewSize.width, y: focus.y / viewSize.height)
+        let worldPoint = CGPoint(
+            x: oldOrigin.x + (focusNorm.x * oldZoomSize.width),
+            y: oldOrigin.y + (focusNorm.y * oldZoomSize.height)
+        )
+        
+        let newOrigin = CGPoint(
+            x: worldPoint.x - (focusNorm.x * newZoomSize.width),
+            y: worldPoint.y - (focusNorm.y * newZoomSize.height)
+        )
+        
+        let newCenter = CGPoint(
+            x: newOrigin.x - (viewSize.width / 2) + (newZoomSize.width / 2),
+            y: newOrigin.y - (viewSize.height / 2) + (newZoomSize.height / 2)
+        )
+        
+        zoomLevelConcretePublished = newZoom
+        centerConcretePublished = newCenter
+        
+        zoomInertiaFocus = focus
+        zoomInertiaViewSize = viewSize
+    }
+    
+    func startZoomInertia(deltaVelocity: CGFloat, focus: CGPoint, viewSize: CGSize) {
+        guard viewSize.width > 0, viewSize.height > 0 else {
+            return
+        }
+        stopZoomInertia()
+        zoomInertiaSpeed = zoomSpeedForLevel(zoomLevelConcretePublished)
+        zoomInertiaVelocity = deltaVelocity
+        zoomInertiaFocus = focus
+        zoomInertiaViewSize = viewSize
+        lastInertiaTick = CFAbsoluteTimeGetCurrent()
+        
+        zoomInertiaTimer = Timer.scheduledTimer(withTimeInterval: 1.0 / 60.0, repeats: true) { [weak self] _ in
+            guard let self = self else { return }
+            let now = CFAbsoluteTimeGetCurrent()
+            let dt = max(now - self.lastInertiaTick, 0)
+            self.lastInertiaTick = now
+            
+            if abs(self.zoomInertiaVelocity) < self.zoomInertiaMinVelocity {
+                self.stopZoomInertia()
+                return
+            }
+            
+            let delta = self.zoomInertiaVelocity * dt
+            self.applyZoom(delta: delta, focus: self.zoomInertiaFocus, viewSize: self.zoomInertiaViewSize)
+            self.zoomInertiaVelocity *= exp(-self.zoomInertiaDamping * dt)
+        }
+        RunLoop.main.add(zoomInertiaTimer!, forMode: .common)
+    }
+    
+    func startZoomInertia(scaleVelocity: CGFloat, focus: CGPoint, viewSize: CGSize) {
+        let deltaVelocity = scaleVelocity / max(zoomInertiaSpeed, 0.0001)
+        startZoomInertia(deltaVelocity: deltaVelocity, focus: focus, viewSize: viewSize)
+    }
+    
+    func stopZoomInertia() {
+        zoomInertiaTimer?.invalidate()
+        zoomInertiaTimer = nil
+        zoomInertiaVelocity = 0
+    }
+    
     func setColorScheme(_ scheme: UInt32) {
         print("Color scheme changed from \(selectedColorSchemeConcretePublished) to \(scheme)")
         selectedColorSchemeConcretePublished = scheme
@@ -106,10 +198,32 @@ final class MetalbrotRendererViewModel: MetalbrotViewModelInterface {
     @Published private var centerConcretePublished: CGPoint
     @Published private var selectedColorSchemeConcretePublished: UInt32
     
+    private let zoomSpeed: CGFloat
+    private let zoomSpeedMinFactor: CGFloat = 0.05
+    private let zoomSpeedMaxFactor: CGFloat = 2.0
+    private let zoomInertiaDamping: CGFloat = 6.0
+    private let zoomInertiaMinVelocity: CGFloat = 5.0
+    private var zoomInertiaVelocity: CGFloat = 0
+    private var zoomInertiaFocus: CGPoint = .zero
+    private var zoomInertiaViewSize: CGSize = .zero
+    private var zoomInertiaTimer: Timer?
+    private var zoomInertiaSpeed: CGFloat = 0
+    private var lastInertiaTick: CFAbsoluteTime = 0
+    
     init(){
+        #if os(macOS)
+        zoomSpeed = 0.0035
+        #else
+        zoomSpeed = 0.0020
+        #endif
         zoomLevelConcretePublished = 1
         centerConcretePublished = .zero
         selectedColorSchemeConcretePublished = 1 // Default to sunset scheme
+    }
+    
+    private func zoomSpeedForLevel(_ level: CGFloat) -> CGFloat {
+        let clamped = min(max(level, zoomSpeedMinFactor), zoomSpeedMaxFactor)
+        return zoomSpeed * clamped
     }
     
 }


### PR DESCRIPTION
## Summary
- Add continuous, focus-anchored zoom with platform-tuned sensitivity and inertia
- Improve pan/zoom stability across macOS and iOS
- Expand palettes to 10 and add smooth, zoom-aware color cycling

## Changes
- New zoom helpers and inertia logic in Metalbrot renderer view model
- Updated gesture handling for focal-point zoom and inertia
- Added 7 new palette functions and smooth iteration coloring in shader

## Suggested next steps
- Try increasing iteration count dynamically with zoom to preserve detail
- Expose palette names and color density controls in UI
- Add tests for zoom math and palette cycling logic
